### PR TITLE
Pass flags from `webui-user.bat` to `webui.bat`

### DIFF
--- a/webui-user.bat
+++ b/webui-user.bat
@@ -5,4 +5,4 @@ set GIT=
 set VENV_DIR=
 set COMMANDLINE_ARGS=
 
-call webui.bat
+call webui.bat %*


### PR DESCRIPTION
I was trying to pass flags to `webui-user.bat` but realized that the flags aren't propagated. I don't know if this was intentional but since the NVIDIA installation guide had suggested I use this script, I thought this might be a small change that could alleviate some confusion.